### PR TITLE
Gulp-useref V3 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,10 +21,9 @@ Elixir.extend('useref', function(config, opts) {
     new Task('useref', function() {
 
         var src = path.join(config.baseDir, !!config.src ? config.src : config.searchLevel);
-        var assets = $.useref.assets(opts);
 
         return gulp.src(src)
-            .pipe(assets)
+            .pipe(useref(opts))
             .pipe(config.minifyJs ? $.if('**/*.js', $.uglify()) : util.noop())
             .pipe(config.minifyCss ? $.if('**/*.css', $.csso()) : util.noop())
             .pipe(gulp.dest(config.outputDir))


### PR DESCRIPTION
Fix broken call with gulp-useref V3 (TypeError: $.useref.assets is not a function). See more here: https://www.npmjs.com/package/gulp-useref (Migration from v2 API)